### PR TITLE
EAP-aka-prime: fix module name in eap config file

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -77,6 +77,7 @@ eap {
 	type = peap
 #	type = fast
 #	type = aka
+#	type = aka_prime
 #	type = sim
 
 	#
@@ -1549,7 +1550,7 @@ eap {
 	#
 	#  ### EAP-AKA-Prime
 	#
-	aka-prime {
+	aka_prime {
 		#
 		#  network_name:: The default value used for AT_KDF_INPUT
 		#


### PR DESCRIPTION
PR's text:
```
Update eap config file to reflect eap.aka_prime module naming convention.

Otherwise, instantiating module "eap.aka_prime" will fail with:
```
Instantiating module "eap.aka"
Instantiating module "eap.aka_prime"
ASSERT FAILED src/modules/rlm_eap/types/rlm_eap_aka_prime/rlm_eap_aka_prime.c[143]: server_cs
```
```

link to original PR: `https://github.com/FreeRADIUS/freeradius-server/pull/3254`