### PR TITLE
Do not use PyFrame_GetLineNumber with Python 2.6

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -238,7 +238,11 @@ static void python_error_log(void)
 			ERROR("[%ld] %s:%d at %s()",
 				fnum,
 				PyString_AsString(cur_frame->f_code->co_filename),
+#if PY_VERSION_HEX >= 0x02070000
 				PyFrame_GetLineNumber(cur_frame),
+#else
+				cur_frame->f_lineno,
+#endif
 				PyString_AsString(cur_frame->f_code->co_name)
 			);
 		}


### PR DESCRIPTION
PR's text:
```
PyFrame_GetLineNumber does not exist in Python 2.6, but you can access to the line number directly by using cur_frame->f_lineno.

I haven't used PyInt_AsLong since it generated segmentation fault, while accessing to the value directly works.

Fixes #3334
```

link to original PR: `https://github.com/FreeRADIUS/freeradius-server/pull/3336`