### PR TITLE
Allow use of password preparation methods with rlm_eap_pwd

### DIFF
--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -318,6 +318,10 @@ ATTRIBUTE	EAP-Sim-Algo-Version			1216	integer
 ATTRIBUTE	Outer-Realm-Name			1218	string
 ATTRIBUTE	Inner-Realm-Name			1219	string
 
+ATTRIBUTE	EAP-Pwd-Password-Hash			1220	octets
+ATTRIBUTE	EAP-Pwd-Password-Salt			1221	octets
+ATTRIBUTE	EAP-Pwd-Password-Prep			1222	byte
+
 #
 #	Range:	1280 - 1535
 #		EAP-type specific attributes

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/eap_pwd.h
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/eap_pwd.h
@@ -102,6 +102,10 @@ typedef struct _pwd_session_t {
     EC_POINT *my_element;
     EC_POINT *peer_element;
     uint8_t my_confirm[SHA256_DIGEST_LENGTH];
+    uint8_t prep;
+    uint8_t salt_present;
+    uint8_t salt_len;
+    uint8_t salt[255];
 } pwd_session_t;
 
 int compute_password_element(pwd_session_t *sess, uint16_t grp_num,

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/rlm_eap_pwd.h
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/rlm_eap_pwd.h
@@ -44,6 +44,8 @@ typedef struct _eap_pwd_t {
     uint32_t	fragment_size;
     char const	*server_id;
     char const	*virtual_server;
+    int32_t	prep;
+    int32_t	unhex;
 } eap_pwd_t;
 
 #endif  /* _RLM_EAP_PWD_H */


### PR DESCRIPTION
PR's text:
```
RFC 5931 and RFC 8146 specify multiple password preparation methods, in order to enable the reuse of different password hashs stored on server side.

This patch adds support for control:NT-Password and a generic interface using EAP-Pwd-Password-Hash, EAP-Pwd-Password-Salt and EAP-Pwd-Password-Prep attributes to support them all without needing to implement each hash function in rlm_eap_pwd.

Tested against eapol_test from wpa_supplicant/hostapd.

Signed-off-by: Michael Braun <michael-dev@fami-braun.de>
```

link to original PR: `https://github.com/FreeRADIUS/freeradius-server/pull/3344`